### PR TITLE
Add user.js and clarify Firefox Flathub benefits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,11 +1380,19 @@ It's important to ensure that the Windows 11 VM properties are set to use `QXL` 
 
 ## 🌍 Firefox
 
-### Installation
+This section will explain common security and privacy changes to harden Firefix.
 
-For security purposes, it's better to run Firefox as a Flatpak instead of from RPM. Flatpak uses bubblewrap for namespace isolation (mount, PID, network options, etc.) and provides a strong default sandbox at low effort. 
+For security purposes, it _may_ be better to run Firefox as a Flatpak instead of from RPM, depending on your security needs. 
 
-First, install Firefox from Flathub:
+Flatpak uses bubblewrap for namespace isolation (mount, PID, network options, etc.) and provides a strong default sandbox at low effort. You can, for example, restrict Firefox from reading `$HOME` with Flatpak permissions.
+
+However, running Firefox as a Flatpak can introduce problems with hardware acceleration and may interfere with some developer workflows. If you do decide to install and use Firefox from Flathub, see the following subsection.
+
+Skip the Flathub installation section if you want to keep using Firefox from RPM.
+
+### Flathub Installation
+
+Install Firefox from Flathub:
 
 ```bash
 flatpak install flathub org.mozilla.firefox
@@ -1459,7 +1467,7 @@ Attribution is a way to track whether ads served to you were effective in gettin
 privacy.resistFingerprinting = true
 ```
 
-This setting improves your defenses against [browser fingerprinting](https://coveryourtracks.eff.org/learn).
+This setting improves your defenses against [browser fingerprinting](https://coveryourtracks.eff.org/learn). However, it may also break certain site layouts.
 
 ```
 dom.event.clipboardevents.enabled = false
@@ -1471,7 +1479,39 @@ This setting prevents websites from knowing if you used copy or paste commands a
 webgl.disabled = true
 ```
 
-This command disables WebGL. If you never visit sites with WebGL content then it can be safely disabled.
+If you never visit sites with WebGL content then it can be safely disabled. However, disabling WebGL can break some Unity development workflows.
+
+### Set a `user.js` file in your profile directory
+
+To avoid setting and re-setting stuff in `about:config` on every fresh install, you can instead drop a `user.js` file into your profile directory. The `user.js` file will look something like this:
+
+```js
+user_pref("privacy.resistFingerprinting", true);
+user_pref("privacy.query_stripping.enabled", true);
+user_pref("dom.security.https_only_mode", true);
+```
+
+[View a complete user.js designed for developer workstations](/examples/firefox-profile-developer/user.js).
+
+> ⚠️ Values in `user.js` override changes you make to `about:config`, not the other way around.
+
+Place `user.js` files into Firefox profile folders:
+
+```
+~/.mozilla/firefox/<profile-folder>/user.js
+```
+
+### Use different Firefox profiles
+
+You can use different Firefox profiles depending on role. For development, you can create a `user-dev` profile which has some relaxed security/privacy settings for OAuth2 flows, and a `user-browse` profile for when you want stricter privacy and security.
+
+To manage profiles, run:
+
+```bash
+firefox --ProfileManager
+```
+
+Each profile gets its own directory in `~/.mozilla/firefox/` and can therefore have its own `user.js` file.
 
 ## Thunderbird
 

--- a/examples/firefox-profile-developer/user.js
+++ b/examples/firefox-profile-developer/user.js
@@ -1,0 +1,70 @@
+// Blank startup page
+user_pref("browser.startup.homepage", "chrome://browser/content/blanktab.html");
+
+// Avoid containerizing data so site A cannot see site B's cookies, even without an extension; annoyance, will cause breakages for developers
+user_pref("privacy.firstparty.isolate", false);
+
+// Avoid OCSP hardening; will result in breakages/annoyances on a dev box
+user_pref("security.OCSP.require", false);
+
+// Avoid sanitize on close; will cause annoyances
+user_pref("privacy.sanitize.sanitizeOnShutdown", false);
+
+// Strict tracking protection
+user_pref("privacy.trackingprotection.enabled", true);
+user_pref("privacy.trackingprotection.socialtracking.enabled", true);
+
+// Disallow attribution reporting submission behavior meant for ad measurement
+user_pref("dom.private-attribution.submission.enabled", false);
+
+// HTTPS-only mode
+user_pref("dom.security.https_only_mode", true);
+
+// Reduce DNS & speculative connections
+user_pref("network.dns.disablePrefetch", true);
+user_pref("network.prefetch-next", false);
+user_pref("network.http.speculative-parallel-limit", 0);
+user_pref("network.predictor.enabled", false);
+
+// Basic fingerprint resistance (safe for dev)
+user_pref("privacy.resistFingerprinting", true);
+
+// Disable telemetry
+user_pref("datareporting.healthreport.uploadEnabled", false);
+user_pref("toolkit.telemetry.enabled", false);
+user_pref("toolkit.telemetry.unified", false);
+user_pref("browser.ping-centre.telemetry", false);
+
+// Harden link tracking
+user_pref("privacy.query_stripping.enabled", true);
+user_pref("privacy.query_stripping.enabled.pbmode", true);
+
+// Clipboard hardening (non-breaking)
+user_pref("dom.events.asyncClipboard.readText", false);
+user_pref("dom.events.asyncClipboard.read", false);
+
+// Keep WebGL enabled if doing Unity testing
+user_pref("webgl.disabled", true);
+user_pref("webgl.min_capability_mode", true);
+
+// Keep WebRTC enabled (may be needed for dev tools)
+// Set to false if not needed
+// user_pref("media.peerconnection.enabled", false);
+
+// Disable battery API
+user_pref("dom.battery.enabled", false);
+
+// Disable gamepad API
+user_pref("dom.gamepad.enabled", false);
+
+// Disable disk cache (optional strong privacy)
+user_pref("browser.cache.disk.enable", false);
+
+// DevTools safe settings
+user_pref("devtools.debugger.remote-enabled", false);
+
+// Strengthen TLS
+user_pref("security.tls.enable_0rtt_data", false);
+
+// Disable password saving (use Bitwarden instead)
+// user_pref("signon.rememberSignons", false);


### PR DESCRIPTION
Fixes #19 
Fixes #21 

This PR would:
- add an example `user.js` tuned for developer workstations
- clarify that Firefox installed from Flathub is not necessarily better than installing it from RPM (the default in Fedora 43)

One con of Flatpak installation of Firefox is GPU acceleration nuisances/crashes/instability.

The `user.js` provided in the `examples` folder is not 100% privacy-tuned. Some good privacy and security settings are purposely disabled to preserve developer productivity and sanity.