### PR TITLE
Add git to common tools command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sudo fwupdmgr update
 Let's next install some common and useful development tools:
 
 ```bash
-sudo dnf -y install make curl
+sudo dnf -y install make curl git
 ```
 
 ## Add Flathub


### PR DESCRIPTION
This PR will add `git` to the list of common tools installed at the beginning of the guide.

Fixes #37 